### PR TITLE
Add configuration for recording time

### DIFF
--- a/config/top.php
+++ b/config/top.php
@@ -5,4 +5,9 @@ return [
      * Provide a redis connection from config/database.php
     */
     'connection' => env('TOP_REDIS_CONNECTION', 'default'),
+
+    /*
+     * The time (in seconds) that data will be recorded and aggregated
+    */
+    'recording_time' => env('TOP_RECORDING_TIME', 5),
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -36,8 +36,10 @@ class ServiceProvider extends BaseServiceProvider
             return;
         }
 
-        $dispatcher->subscribe(RequestListener::class);
-        $dispatcher->subscribe(CacheListener::class);
-        $dispatcher->subscribe(DatabaseListener::class);
+        if ($this->app['config']->get('top.recording_time') > 0) {
+            $dispatcher->subscribe(RequestListener::class);
+            $dispatcher->subscribe(CacheListener::class);
+            $dispatcher->subscribe(DatabaseListener::class);
+        }
     }
 }


### PR DESCRIPTION
Allow a user to configure the recording time for top, allowing for aggregation of requests longer than 5 seconds.

Also added a check in the ServiceProvider to only register event listeners when a valid recording time is set. This provides the added bonus disable this package by setting the recording time to 0.