### PR TITLE
Use trap method instead of pcntl_signal for better signal handling

### DIFF
--- a/src/Commands/TopCommand.php
+++ b/src/Commands/TopCommand.php
@@ -28,11 +28,11 @@ class TopCommand extends Command
         Loop::addPeriodicTimer(0.5, fn () => $guiBuilder->moveToTop()->render());
         Loop::addPeriodicTimer(1, fn () => $this->feed($guiBuilder));
 
-        pcntl_signal(SIGINT, function () use ($guiBuilder) {
+        $this->trap(SIGINT, function () use ($guiBuilder) {
             $guiBuilder
                 ->exitAlternateScreen()
                 ->showCursor();
-            exit(0);
+            exit();
         });
     }
 


### PR DESCRIPTION
### Description

This PR replaces the direct use of `pcntl_signal` with the `trap` method provided by the `InteractsWithSignals` trait in the `TopCommand` class. The `trap` method allows for multiple handlers for the same signal, preventing potential issues in environments like Laravel Octane where multiple handlers might be necessary.

### Changes

- Replaced `pcntl_signal(SIGINT, function () use ($guiBuilder) { ... });` with `$this->trap(SIGINT, function () use ($guiBuilder) { ... });`

### Benefits

- Supports multiple handlers for signals, ensuring that no handlers are overwritten.
- Provides better integration with Laravel's command lifecycle and signal management.
- Enhances the robustness and reliability of signal handling in the application.

### Testing

- Tested the changes locally to ensure that the signal handling works as expected.
- Verified that the application exits alternate screen mode and shows the cursor upon receiving `SIGINT`.
