### PR TITLE
Laravel 13.x compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-L${{ matrix.laravel }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3]
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Since the data is stored in Redis, the output of the top command reflects data f
 
 ## Installation
 
-> Compatible with Laravel 10, Laravel 11, and Laravel Octane.
+> Compatible with Laravel 10+ and Laravel Octane.
 
 > **Requires [PHP 8.2+](https://php.net/releases/) | [Redis 5.0+](https://redis.io)**
 

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^8.2.0",
         "ext-pcntl": "*",
-        "laravel/framework": "^10.0|^11.0|^12.0",
+        "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
         "react/event-loop": "^1.5"
     },
     "require-dev": {
         "laravel/pint": "^1.15",
         "mockery/mockery": "^1.6",
-        "pestphp/pest": "^2.34|^3.7",
+        "pestphp/pest": "^2.34|^3.7|^4.4",
         "phpstan/phpstan": "^1.10|^2.1"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Bumps `laravel/framework` constraint to allow `^12.0|^13.0` and widens `pestphp/pest` / `phpstan/phpstan` constraints (from Shift PR #9)
- Updates the test matrix to cover Laravel 10–13 with the L13/PHP8.2 combo excluded
- Bumps deprecated `actions/checkout@v2 → v4` and `actions/cache@v1 → v4` so jobs are no longer auto-failed by GitHub

Replaces #9 — same Shift commits with the workflow action versions fixed so CI can actually run.

## Test plan
Verified locally with `act`:
- [x] L13 / PHP 8.3 / prefer-stable — 19 passed
- [x] L13 / PHP 8.3 / prefer-lowest — 19 passed
- [x] L10 / PHP 8.2 / prefer-lowest — 19 passed
- [ ] Full GitHub Actions matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)